### PR TITLE
added a target to build a static library + bugfix: don't try copying more than available in the input buffer 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ tmp
 *~
 *.so
 *.o
+*.a
 test/test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+ifeq ($(UNAME), Darwin)
+SHAREDFLAGS = -dynamiclib
+SHAREDEXT = dylib
+else
+SHAREDFLAGS = -shared
+SHAREDEXT = so
+endif
+
+ifeq ("$(LIBDIR)", "")
+LIBDIR=/usr/local/lib
+endif
+
+ifeq ("$(INCDIR)", "")
+INCDIR=/usr/local/include
+endif
+
+all:
+	make -C src all
+clean:
+	make -C src clean
+install:
+	 @echo "Installing libraries in $(LIBDIR)"; \
+	 cp -v src/libsiphash.a $(LIBDIR)/;\
+	 cp -v src/libsiphash.$(SHAREDEXT) $(LIBDIR)/;\
+	 echo "Installing headers in $(INCDIR)"; \
+	 cp -v src/*.h $(INCDIR)/;

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,8 @@
 # Simple Makefile for siphash
 
 CC= gcc
-CFLAGS= -fPIC -Wall
-CPPFLAGS= -I.
+CFLAGS+= -fPIC -Wall
+CPPFLAGS+= -I.
 DEPS= siphash.h
 OBJ= siphash.o
 DLEXT = so

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,15 +9,23 @@ DLEXT = so
 
 RM= rm -f
 
+all: static shared
+
+shared: libsiphash.$(DLEXT)
+
+static: $(OBJ) siphash.a
+
 %.o: %.c $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS) $(CPPFLAGS)
 
-siphash: siphash.$(DLEXT)
-siphash.$(DLEXT): $(OBJ)
+libsiphash.$(DLEXT): $(OBJ)
 	$(CC) -shared -o $@ $^
+siphash.a:
+	ar -r libsiphash.a *.o
 
 clean:
 	@-$(RM) *.o
 	@-$(RM) *.$(DLEXT)
+	@-$(RM) *.a
 
 .PHONY: siphash clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 # Simple Makefile for siphash
 
 CC= gcc
-CFLAGS+= -fPIC -Wall
+CFLAGS+= -fPIC -Wall -Wno-strict-aliasing
 CPPFLAGS+= -I.
 DEPS= siphash.h
 OBJ= siphash.o

--- a/src/siphash.c
+++ b/src/siphash.c
@@ -233,6 +233,9 @@ int_sip_pre_update(sip_state *state, uint8_t **pdata, size_t *plen)
     if (!state->buflen) return;
 
     to_read = sizeof(uint64_t) - state->buflen;
+
+    if (to_read > *plen) return;
+
     memcpy(state->buf + state->buflen, *pdata, to_read);
     m = U8TO64_LE(state->buf);
     int_sip_update_block(state, m);

--- a/src/siphash.c
+++ b/src/siphash.c
@@ -269,10 +269,12 @@ int_sip_update(sip_state *state, uint8_t *data, size_t len)
     uint64_t *data64;
 
     state->msglen_byte = state->msglen_byte + (len % 256);
-    data64 = (uint64_t *) data;
 
     int_sip_pre_update(state, &data, &len);
+    if (len == 0)
+        return;
 
+    data64 = (uint64_t *) data;
     end = data64 + (len / sizeof(uint64_t));
 
 #if BYTE_ORDER == LITTLE_ENDIAN

--- a/src/siphash.c
+++ b/src/siphash.c
@@ -331,9 +331,13 @@ sip_hash_new(uint8_t key[16], int c, int d)
 {
     sip_hash *h = NULL;
 
-    if (!(h = (sip_hash *) malloc(sizeof(sip_hash)))) return NULL;
+    if (!(h = (sip_hash *) malloc(sizeof(sip_hash))))
+        return NULL;
     h->state = NULL;
-    if (!(h->state = (sip_state *) malloc(sizeof(sip_state)))) return NULL;
+    if (!(h->state = (sip_state *) malloc(sizeof(sip_state)))) {
+        free(h);
+        return NULL;
+    }
     h->state->c = c;
     h->state->d = d;
     h->state->buflen = 0;
@@ -357,7 +361,8 @@ sip_hash_final(sip_hash *h, uint8_t **digest, size_t* len)
     uint8_t *ret;
 
     h->methods->final(h->state, &digest64);
-    if (!(ret = (uint8_t *)malloc(sizeof(uint64_t)))) return 0;
+    int psize = sizeof(uint64_t);
+    if (!(ret = malloc(psize))) return 0;
     U64TO8_LE(ret, digest64);
     *len = sizeof(uint64_t);
     *digest = ret;


### PR DESCRIPTION
renamed the shared object using the standard 'lib' prefix

added a main Makefile to allow building/installing the library from the top directory

bugfix: don't try copying more than available in the input buffer … (MAJOR!!)

sip_hash_final() will take care of padding the buffer (to be multiple of uint64_t) if necessary (MAJOR!!)

bugfix in the streaming-api implementation (was not working in most cases)  (MAJOR!!)

one more bugfix: the data64 pointer MUST be set after calling int_sip_pre_update() (MAJOR!!)
